### PR TITLE
ci: fix build, install, and export commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Delete any cached octave build results
         run: rm -rf .flatpak-builder/cache/refs/heads/*/build-octave
 
-      - name: Build
-        run: flatpak-builder --user --install --install-deps-from=flathub --assumeyes --default-branch=nightly octave org.octave.Octave.yaml
+      - name: Build and install
+        run: flatpak-builder --user --assumeyes --default-branch=nightly --force-clean --install-deps-from=flathub --install octave org.octave.Octave.yaml
 
       - name: Test running octave --version
         run: flatpak run --branch=nightly org.octave.Octave --version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Delete any cached octave build results
         run: rm -rf .flatpak-builder/cache/refs/heads/*/build-octave
 
-      - name: Build
-        run: flatpak-builder --user --install --install-deps-from=flathub --assumeyes --default-branch=nightly --gpg-sign=${{ steps.gpg.outputs.keyid }} --repo=repo octave org.octave.Octave.yaml
+      - name: Build and install
+        run: flatpak-builder --user --assumeyes --default-branch=nightly --force-clean --install-deps-from=flathub --install octave org.octave.Octave.yaml
 
       - name: Test running octave --version
         run: flatpak run --branch=nightly org.octave.Octave --version
@@ -64,6 +64,9 @@ jobs:
 
       - name: Dump octave build configuration
         run: flatpak run --branch=nightly org.octave.Octave --eval "disp (__octave_config_info__)"
+
+      - name: Build and export
+        run: flatpak-builder --user --assumeyes --default-branch=nightly --force-clean --gpg-sign=${{ steps.gpg.outputs.keyid }} --install-deps-from=flathub --repo=repo octave org.octave.Octave.yaml
 
       - name: Update repository metadata
         run: flatpak build-update-repo --gpg-sign=${{ steps.gpg.outputs.keyid }} --default-branch=nightly repo


### PR DESCRIPTION
Use the same build and install steps for testing changes on all builds.
Use separate build and export step for deploying nightly.